### PR TITLE
Oppgraderer til node20, node16 er depricated

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,5 +13,5 @@ inputs:
     required: false
 
 runs:
-  using: "node16"
+  using: "node20"
   main: "src/main.js"


### PR DESCRIPTION
https://trello.com/c/gj1F535i/4152-oppdater-andrlriis-slack-notification-action-til-node-20-node-16-er-depricated-av-github